### PR TITLE
Full bool values support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ BEM class name formatter
 
 ## Example
 
-**Simple**
+### Simple
 
 ```js
 var b = require('b_');
@@ -23,7 +23,7 @@ b('button', {hidden: false}) === 'button';
 b('button', {hidden: true}) === 'button button_hidden';
 ```
 
-**Alternative BEM syntax**
+### Alternative BEM syntax
 
 ```js
 var B = require('b_').B;
@@ -39,17 +39,27 @@ b('block', 'elem', {mod1: true, mod2: false, mod3: 'mod3'}) ===
 'block-elem block-elem--mod1 block-elem--mod3-mod3 ';
 ```
 
-**[BEViS](https://github.com/bevis-ui/docs) syntax**
+### [BEViS](https://github.com/bevis-ui/docs) syntax
 
 ```js
 var B = require('b_').B;
 var b = B({isFullModifier: false});
 
-b('button_call-for-action', {disabled: true, focused: 'yes'})) ===
+b('button_call-for-action', {disabled: true, focused: 'yes'}) ===
 'button_call-for-action _disabled _focused_yes';
 ```
 
-**React example**
+### Full bool values in modifiers
+
+```js
+var B = require('b_').B;
+var b = B({isFullBoolValue: true});
+
+b('button', {disabled: true, focused: false}) ===
+'button button_disabled_true button_focused_false';
+```
+
+### React example
 
 ```jsx
 var b = require('b_').with('b-button');

--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ function (root, factory) {
      * @param {string} [options.modValueSeparator='_']
      * @param {string} [options.classSeparator=' ']
      * @param {string} [options.isFullModifier=true]
+     * @param {string} [options.isFullBoolValue=false]
      *
      * @constructor
      */
@@ -39,6 +40,7 @@ function (root, factory) {
         this.modValueSeparator = options.modValueSeparator || '_';
         this.classSeparator = options.classSeparator || ' ';
         this.isFullModifier = typeof options.isFullModifier === 'undefined' ? true : options.isFullModifier;
+        this.isFullBoolValue = typeof options.isFullBoolValue === 'undefined' ? false : options.isFullBoolValue;
     }
 
     BemFormatter.prototype = {
@@ -53,16 +55,21 @@ function (root, factory) {
         _stringifyModifier: function (base, modifierKey, modifierValue) {
             var result = '';
 
-            // Ignore false or undefined values
-            if (modifierValue === false || typeof modifierValue === 'undefined') {
+            // Ignore undefined values
+            if (typeof modifierValue === 'undefined') {
+                return result;
+            }
+
+            // If not using full bools ignore false values
+            if (!this.isFullBoolValue && modifierValue === false) {
                 return result;
             }
 
             // Makes block__elem_{modifierKey}
             result += this.classSeparator + base + this.modSeparator + modifierKey;
 
-            // If modifier value is just true skip `modifierValue`
-            if (modifierValue !== true) {
+            // If not using full bools skip true `modifierValue`
+            if (this.isFullBoolValue || modifierValue !== true) {
                 // Makes block__elem_{modifierKey}_{modifierValue}
                 result += this.modValueSeparator + String(modifierValue);
             }

--- a/test/test.b_.js
+++ b/test/test.b_.js
@@ -21,7 +21,8 @@ describe('b_', function () {
         modSeparator: '{modSeparator}',
         modValueSeparator: '{modValueSeparator}',
         classSeparator: '{classSeparator}',
-        isFullModifier: true
+        isFullModifier: true,
+        isFullBoolValue: false
     };
 
     it('is alias to new B().stringify', function () {
@@ -120,6 +121,11 @@ describe('b_', function () {
             it('can use short modifiers', function () {
                 b = new B({isFullModifier: false});
                 expect(b.stringify('block_view', {state1: 1, state2: 2})).to.eql('block_view _state1_1 _state2_2');
+            });
+
+            it('can use full bool value modifiers', function () {
+                b = new B({isFullBoolValue: true});
+                expect(b.stringify('block_view', {state1: true, state2: false})).to.eql('block_view block_view_state1_true block_view_state2_false');
             });
 
         });


### PR DESCRIPTION
Hi! Tired of toString'ing things `{ mod: (something === anythingElse).toString() }` everywhere, so I've added an option to stringify bool values fully as in oldschool bem :)

If you're in doubt merge it or not — don't think, just merge :D